### PR TITLE
Fix: Issue with switching between apps with jobs and without

### DIFF
--- a/app/view/mod_job_list.R
+++ b/app/view/mod_job_list.R
@@ -97,7 +97,7 @@ server <- function(id, state) {
 
     state$selected_job <- reactive({
       index <- getReactableState("job_list_table", "selected")
-      if (isTruthy(index)) {
+      if (isTruthy(index) && length(job_list_data()) > 0) {
         list(
           "key" = job_list_data()[index, ]$key,
           "id" = job_list_data()[index, ]$id


### PR DESCRIPTION
*Have you read the [Contributing Guidelines](https://github.com/Appsilon/.github/blob/main/CONTRIBUTING.md)?*

Closes #8 

## Description
- We now check for the `job_list()` to have valid length before proceeding, therefore fixing the reactivity.

## Definition of Done
- [x] The change is thoroughly documented.
- [x] The CI passes (`R CMD check`, linter, unit tests, spelling).
- [x] Any generated files have been updated (e.g. `.Rd` files with `roxygen2::roxygenise()`)
