### PR TITLE
Refactor: spring clean up 🧹

### DIFF
--- a/app/main.R
+++ b/app/main.R
@@ -1,27 +1,16 @@
-# nolint start: box_func_import_count_linter
 box::use(
-  dplyr[select],
-  magrittr[`%>%`],
   shiny[
     div,
     fluidPage,
-    img,
     isTruthy,
     moduleServer,
     NS,
-    observeEvent,
-    p,
     reactive,
     reactiveValues,
-    removeUI,
     renderUI,
-    tagList,
-    tags,
     uiOutput
   ],
-  shinycssloaders[withSpinner],
 )
-# nolint end
 
 box::use(
   app/logic/api_utils[get_app_list],

--- a/app/main.R
+++ b/app/main.R
@@ -68,76 +68,59 @@ server <- function(id) {
 
     ns <- session$ns
 
+    app_list <- get_app_list()
+
     mod_header$server("header")
 
     state <- reactiveValues()
     state$selected_app <- reactive({})
     state$selected_job <- reactive({})
 
-    app_list <- reactive({
-      get_app_list()
-    })
-
     mod_app_table$server(
       "app_table",
-      app_list(),
+      app_list,
       state
     )
 
-    observeEvent(state$selected_app()$guid, {
+    mod_job_list$server(
+      "job_list",
+      state
+    )
 
-      if (isTruthy(state$selected_app()$guid)) {
+    mod_logs$server(
+      "logs",
+      state
+    )
 
-        output$job_list_pane <- renderUI({
-          mod_job_list$ui(ns("job_list"))
-        })
-
-        mod_job_list$server(
-          "job_list",
-          state
-        )
-
-      } else {
-
-        removeUI(ns("job_list_pane"))
-
-      }
-    }, ignoreNULL = FALSE)
-
-    observeEvent(state$selected_job()$key, {
-
-      if (isTruthy(state$selected_job()$key)) {
-
-        output$logs_pane <- renderUI({
-          mod_logs$ui(ns("logs"))
-        })
-
-        mod_logs$server(
-          "logs",
-          state
-        )
-      } else {
-
-        if (!inherits(app_list(), "data.frame")) {
-          empty_state <- renderUI({
-            generate_empty_state_ui(
-              text = "Oops! Can't read apps from Posit Connect.",
-              image_path = "static/illustrations/missing_apps.svg"
-            )
-          })
-        } else {
-          empty_state <- renderUI({
-            generate_empty_state_ui(
-              text = "Select an application and a job to view logs.",
-              image_path = "static/illustrations/empty_state.svg"
-            )
-          })
-        }
-
-        output$logs_pane <- empty_state
+    output$job_list_pane <- renderUI({
+      if (!isTruthy(state$selected_app()$guid)) {
+        return(NULL)
       }
 
-    }, ignoreNULL = FALSE)
+      mod_job_list$ui(ns("job_list"))
+    })
+
+    output$logs_pane <- renderUI({
+      if (!is.data.frame(app_list) || nrow(app_list) == 0) {
+        return(
+          generate_empty_state_ui(
+            text = "Oops! Can't read apps from Posit Connect.",
+            image_path = "static/illustrations/missing_apps.svg"
+          )
+        )
+      }
+
+      if (!isTruthy(state$selected_job()$key)) {
+        return(
+          generate_empty_state_ui(
+            text = "Select an application and a job to view logs.",
+            image_path = "static/illustrations/empty_state.svg"
+          )
+        )
+      }
+
+      mod_logs$ui(ns("logs"))
+    })
 
   })
 }

--- a/app/main.R
+++ b/app/main.R
@@ -5,8 +5,6 @@ box::use(
     isTruthy,
     moduleServer,
     NS,
-    reactive,
-    reactiveValues,
     renderUI,
     uiOutput
   ],
@@ -61,28 +59,14 @@ server <- function(id) {
 
     mod_header$server("header")
 
-    state <- reactiveValues()
-    state$selected_app <- reactive({})
-    state$selected_job <- reactive({})
+    selected_app_ <- mod_app_table$server("app_table", app_list)$selected_app_
 
-    mod_app_table$server(
-      "app_table",
-      app_list,
-      state
-    )
+    selected_job_ <- mod_job_list$server("job_list", selected_app_)$selected_job_
 
-    mod_job_list$server(
-      "job_list",
-      state
-    )
-
-    mod_logs$server(
-      "logs",
-      state
-    )
+    mod_logs$server("logs", selected_app_, selected_job_)
 
     output$job_list_pane <- renderUI({
-      if (!isTruthy(state$selected_app()$guid)) {
+      if (!isTruthy(selected_app_()$guid)) {
         return(NULL)
       }
 
@@ -99,7 +83,7 @@ server <- function(id) {
         )
       }
 
-      if (!isTruthy(state$selected_job()$key)) {
+      if (!isTruthy(selected_job_()$key)) {
         return(
           generate_empty_state_ui(
             text = "Select an application and a job to view logs.",

--- a/app/view/mod_app_table.R
+++ b/app/view/mod_app_table.R
@@ -43,7 +43,7 @@ server <- function(id, app_list) {
 
     output$app_table <- renderReactable({
 
-      if (length(app_list) > 0 && inherits(app_list, "data.frame")) {
+      if (nrow(app_list) > 0 && inherits(app_list, "data.frame")) {
         processed_apps <- app_list %>%
           select(
             guid,
@@ -101,7 +101,7 @@ server <- function(id, app_list) {
     list(
       selected_app_ = reactive({
         index <- getReactableState("app_table", "selected")
-        if (isTruthy(index) && length(app_list > 0)) {
+        if (isTruthy(index) && nrow(app_list) > 0) {
           list(
             "guid" = app_list[index, ]$guid,
             "name" = app_list[index, ]$name

--- a/app/view/mod_app_table.R
+++ b/app/view/mod_app_table.R
@@ -38,7 +38,7 @@ ui <- function(id) {
 }
 
 #' @export
-server <- function(id, app_list, state) {
+server <- function(id, app_list) {
   moduleServer(id, function(input, output, session) {
 
     output$app_table <- renderReactable({
@@ -98,15 +98,17 @@ server <- function(id, app_list, state) {
       )
     })
 
-    state$selected_app <- reactive({
-      index <- getReactableState("app_table", "selected")
-      if (isTruthy(index) && length(app_list > 0)) {
-        list(
-          "guid" = app_list[index, ]$guid,
-          "name" = app_list[index, ]$name
-        )
-      }
-    })
+    list(
+      selected_app_ = reactive({
+        index <- getReactableState("app_table", "selected")
+        if (isTruthy(index) && length(app_list > 0)) {
+          list(
+            "guid" = app_list[index, ]$guid,
+            "name" = app_list[index, ]$name
+          )
+        }
+      })
+    )
 
   })
 

--- a/app/view/mod_job_list.R
+++ b/app/view/mod_job_list.R
@@ -75,7 +75,7 @@ server <- function(id, selected_app_) {
     list(
       selected_job_ = reactive({
         index <- getReactableState("job_list_table", "selected")
-        if (isTruthy(index) && length(job_list_data()) > 0) {
+        if (isTruthy(index) && nrow(job_list_data()) > 0) {
           list(
             "key" = job_list_data()[index, ]$key,
             "id" = job_list_data()[index, ]$id

--- a/app/view/mod_job_list.R
+++ b/app/view/mod_job_list.R
@@ -39,12 +39,12 @@ ui <- function(id) {
 }
 
 #' @export
-server <- function(id, state) {
+server <- function(id, selected_app_) {
   moduleServer(id, function(input, output, session) {
 
     job_list_data <- reactive({
-      req(state$selected_app()$guid)
-      get_job_list(state$selected_app()$guid)
+      req(selected_app_()$guid)
+      get_job_list(selected_app_()$guid)
     })
 
     output$job_list_table <- renderReactable({
@@ -72,15 +72,17 @@ server <- function(id, state) {
 
     })
 
-    state$selected_job <- reactive({
-      index <- getReactableState("job_list_table", "selected")
-      if (isTruthy(index) && length(job_list_data()) > 0) {
-        list(
-          "key" = job_list_data()[index, ]$key,
-          "id" = job_list_data()[index, ]$id
-        )
-      }
-    })
+    list(
+      selected_job_ = reactive({
+        index <- getReactableState("job_list_table", "selected")
+        if (isTruthy(index) && length(job_list_data()) > 0) {
+          list(
+            "key" = job_list_data()[index, ]$key,
+            "id" = job_list_data()[index, ]$id
+          )
+        }
+      })
+    )
 
   })
 }

--- a/app/view/mod_logs.R
+++ b/app/view/mod_logs.R
@@ -70,16 +70,17 @@ server <- function(id, selected_app_, selected_job) {
       }
     )
 
-    observeEvent(selected_job_()$key, {
-      req(selected_job_()$key)
-      output$download_logs <- renderUI({
-        downloadButton(
-          outputId = ns("download"),
-          label = NULL,
-          icon = icon("download"),
-          class = "logs-download"
-        )
-      })
+    output$download_logs <- renderUI({
+      if (is.null(selected_job_()$key)) {
+        return(NULL)
+      }
+
+      downloadButton(
+        outputId = ns("download"),
+        label = NULL,
+        icon = icon("download"),
+        class = "logs-download"
+      )
     })
 
     logs_data <- reactive({

--- a/app/view/mod_logs.R
+++ b/app/view/mod_logs.R
@@ -50,7 +50,7 @@ ui <- function(id) {
 }
 
 #' @export
-server <- function(id, state) {
+server <- function(id, selected_app_, selected_job) {
   moduleServer(id, function(input, output, session) {
 
     ns <- session$ns
@@ -58,20 +58,20 @@ server <- function(id, state) {
     output$download <- downloadHandler(
       filename = function() {
         glue(
-          "{state$selected_app()$name}_{state$selected_job()$id}.txt"
+          "{selected_app_()$name}_{selected_job_()$id}.txt"
         )
       },
       content = function(file) {
         logs <- download_job_logs(
-          state$selected_app()$guid,
-          state$selected_job()$key
+          selected_app_()$guid,
+          selected_job_()$key
         )
         writeLines(logs, file)
       }
     )
 
-    observeEvent(state$selected_job()$key, {
-      req(state$selected_job()$key)
+    observeEvent(selected_job_()$key, {
+      req(selected_job_()$key)
       output$download_logs <- renderUI({
         downloadButton(
           outputId = ns("download"),
@@ -83,10 +83,10 @@ server <- function(id, state) {
     })
 
     logs_data <- reactive({
-      req(state$selected_job()$key)
+      req(selected_job_()$key)
       get_job_logs(
-        state$selected_app()$guid,
-        state$selected_job()$key
+        selected_app_()$guid,
+        selected_job_()$key
       )
     })
 


### PR DESCRIPTION
## Description
A spring clean up:
- removed `state` (`reactiveValues`) in favor of simple reactives that are returned from modules
- pull out `renderUI`s from `observeEvent`s
- fix checks and make them consistent

The goal is to make further changes a bit simpler to implement