### PR TITLE
Refactor: spring clean up 🧹

### DIFF
--- a/app/view/mod_app_table.R
+++ b/app/view/mod_app_table.R
@@ -43,7 +43,7 @@ server <- function(id, app_list) {
 
     output$app_table <- renderReactable({
 
-      if (length(app_list) > 0 && inherits(app_list, "data.frame")) {
+      if (nrow(app_list) > 0 && inherits(app_list, "data.frame")) {
         processed_apps <- app_list %>%
           select(
             guid,
@@ -102,7 +102,7 @@ server <- function(id, app_list) {
     list(
       selected_app_ = reactive({
         index <- getReactableState("app_table", "selected")
-        if (isTruthy(index) && length(app_list > 0)) {
+        if (isTruthy(index) && nrow(app_list) > 0) {
           list(
             "guid" = app_list[index, ]$guid,
             "name" = app_list[index, ]$name

--- a/app/view/mod_app_table.R
+++ b/app/view/mod_app_table.R
@@ -38,7 +38,7 @@ ui <- function(id) {
 }
 
 #' @export
-server <- function(id, app_list, state) {
+server <- function(id, app_list) {
   moduleServer(id, function(input, output, session) {
 
     output$app_table <- renderReactable({
@@ -99,15 +99,17 @@ server <- function(id, app_list, state) {
       )
     })
 
-    state$selected_app <- reactive({
-      index <- getReactableState("app_table", "selected")
-      if (isTruthy(index) && length(app_list > 0)) {
-        list(
-          "guid" = app_list[index, ]$guid,
-          "name" = app_list[index, ]$name
-        )
-      }
-    })
+    list(
+      selected_app_ = reactive({
+        index <- getReactableState("app_table", "selected")
+        if (isTruthy(index) && length(app_list > 0)) {
+          list(
+            "guid" = app_list[index, ]$guid,
+            "name" = app_list[index, ]$name
+          )
+        }
+      })
+    )
 
   })
 

--- a/app/view/mod_job_list.R
+++ b/app/view/mod_job_list.R
@@ -39,12 +39,12 @@ ui <- function(id) {
 }
 
 #' @export
-server <- function(id, state) {
+server <- function(id, selected_app_) {
   moduleServer(id, function(input, output, session) {
 
     job_list_data <- reactive({
-      req(state$selected_app()$guid)
-      get_job_list(state$selected_app()$guid)
+      req(selected_app_()$guid)
+      get_job_list(selected_app_()$guid)
     })
 
     output$job_list_table <- renderReactable({
@@ -73,15 +73,17 @@ server <- function(id, state) {
 
     })
 
-    state$selected_job <- reactive({
-      index <- getReactableState("job_list_table", "selected")
-      if (isTruthy(index) && length(job_list_data()) > 0) {
-        list(
-          "key" = job_list_data()[index, ]$key,
-          "id" = job_list_data()[index, ]$id
-        )
-      }
-    })
+    list(
+      selected_job_ = reactive({
+        index <- getReactableState("job_list_table", "selected")
+        if (isTruthy(index) && length(job_list_data()) > 0) {
+          list(
+            "key" = job_list_data()[index, ]$key,
+            "id" = job_list_data()[index, ]$id
+          )
+        }
+      })
+    )
 
   })
 }

--- a/app/view/mod_job_list.R
+++ b/app/view/mod_job_list.R
@@ -76,7 +76,7 @@ server <- function(id, selected_app_) {
     list(
       selected_job_ = reactive({
         index <- getReactableState("job_list_table", "selected")
-        if (isTruthy(index) && length(job_list_data()) > 0) {
+        if (isTruthy(index) && nrow(job_list_data()) > 0) {
           list(
             "key" = job_list_data()[index, ]$key,
             "id" = job_list_data()[index, ]$id

--- a/app/view/mod_logs.R
+++ b/app/view/mod_logs.R
@@ -50,7 +50,7 @@ ui <- function(id) {
 }
 
 #' @export
-server <- function(id, state) {
+server <- function(id, selected_app_, selected_job_) {
   moduleServer(id, function(input, output, session) {
 
     ns <- session$ns
@@ -58,20 +58,20 @@ server <- function(id, state) {
     output$download <- downloadHandler(
       filename = function() {
         glue(
-          "{state$selected_app()$name}_{state$selected_job()$id}.txt"
+          "{selected_app_()$name}_{selected_job_()$id}.txt"
         )
       },
       content = function(file) {
         logs <- download_job_logs(
-          state$selected_app()$guid,
-          state$selected_job()$key
+          selected_app_()$guid,
+          selected_job_()$key
         )
         writeLines(logs, file)
       }
     )
 
-    observeEvent(state$selected_job()$key, {
-      req(state$selected_job()$key)
+    observeEvent(selected_job_()$key, {
+      req(selected_job_()$key)
       output$download_logs <- renderUI({
         downloadButton(
           outputId = ns("download"),
@@ -83,10 +83,10 @@ server <- function(id, state) {
     })
 
     logs_data <- reactive({
-      req(state$selected_job()$key)
+      req(selected_job_()$key)
       get_job_logs(
-        state$selected_app()$guid,
-        state$selected_job()$key
+        selected_app_()$guid,
+        selected_job_()$key
       )
     })
 

--- a/app/view/mod_logs.R
+++ b/app/view/mod_logs.R
@@ -70,16 +70,17 @@ server <- function(id, selected_app_, selected_job_) {
       }
     )
 
-    observeEvent(selected_job_()$key, {
-      req(selected_job_()$key)
-      output$download_logs <- renderUI({
-        downloadButton(
-          outputId = ns("download"),
-          label = NULL,
-          icon = icon("download"),
-          class = "logs-download"
-        )
-      })
+    output$download_logs <- renderUI({
+      if (is.null(selected_job_()$key)) {
+        return(NULL)
+      }
+
+      downloadButton(
+        outputId = ns("download"),
+        label = NULL,
+        icon = icon("download"),
+        class = "logs-download"
+      )
     })
 
     logs_data <- reactive({


### PR DESCRIPTION
## Description
A spring clean up:
- removed `state` (`reactiveValues`) in favor of simple reactives that are returned from modules
- pull out `renderUI`s from `observeEvent`s
- fix checks and make them consistent

The goal is to make further changes a bit simpler to implement