### PR TITLE
Fix: Edge case for `check_error_text()`

### DIFF
--- a/app/logic/general_utils.R
+++ b/app/logic/general_utils.R
@@ -18,7 +18,7 @@ check_text_error <- function(
   ignore_case = TRUE
 ) {
   grepl(
-    paste(wordlist, collapse = "|"),
+    paste0("^", wordlist, collapse = "|"),
     text,
     ignore.case = ignore_case
   )

--- a/tests/testthat/test-general_utils.R
+++ b/tests/testthat/test-general_utils.R
@@ -34,6 +34,19 @@ describe("check_text_error()", {
     )
   })
 
+  it("handles 'no error' and similar cases gracefully", {
+    expect_true(
+      !check_text_error(
+        "No error detected"
+      )
+    )
+    expect_true(
+      !check_text_error(
+        "No errors found"
+      )
+    )
+  })
+
   it("returns FALSE for non-error keywords", {
     expect_true(
       !check_text_error(


### PR DESCRIPTION
*Have you read the [Contributing Guidelines](https://github.com/Appsilon/.github/blob/main/CONTRIBUTING.md)?*

Closes #22

## Description
- This just adds @vituri's solution on !15
- **This should be merged after !15** ⚠️ 

## Definition of Done
- [x] The change is thoroughly documented.
- [x] The CI passes (`R CMD check`, linter, unit tests, spelling).
- [x] Any generated files have been updated (e.g. `.Rd` files with `roxygen2::roxygenise()`)
