### PR TITLE
Add integration-test note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # LogAnalyzer
 
+> **Note:** This is a test PR from the shinybot + mediforce automated pipeline integration test — safe to close without merging.
+
 The LogAnalyzer open-source app is a simple, plug and play application developed first in collaboration with [Elkem](https://www.elkem.com/). The app provides an ability to get semantically coloured logs for applications deployed on Posit Connect by simply changing the default environment variables and deploying it on Posit Connect. Given the general usefulness of the app, we have decided to share it with the wider community to use and improve upon it. No more sifting through long text files; you can simply find the reds and see where things break. It has never been easier to investigate what goes wrong with your applications.
 
 # How it works?


### PR DESCRIPTION
## What changed

Adds a one-line blockquote note directly under the `# LogAnalyzer` heading in `README.md` stating that this is a test PR from the shinybot + mediforce automated pipeline integration test and is safe to close without merging.

## Why

Requested via a shinybot chat session as an end-to-end verification of the shinybot -> mediforce automated change-request pipeline. This PR is deliberately trivial and is **safe to close without merging**.

## How it was tested

No tests were run. The change is a documentation-only, single-line Markdown addition with no executable code paths. The repo's test suites (`tests/testthat` for R and `tests/cypress` for E2E) require an R/`renv` environment and a running Shiny app respectively, neither of which is available without extra setup, and neither exercises `README.md`.

---

🤖 Opened by the **shinybot-bridge** mediforce workflow, on behalf of a shinybot chat request.